### PR TITLE
Add benchmark for h5py read via gedi_subset's H5DataFrame

### DIFF
--- a/notebooks/first-benchmark.ipynb
+++ b/notebooks/first-benchmark.ipynb
@@ -23,7 +23,7 @@
     "    from gedi_subset.h5frame import H5DataFrame\n",
     "except ImportError:\n",
     "    !pip install git+https://github.com/MAAP-Project/gedi-subsetter.git@0.6.0\n",
-    "    from gedi_subset.h5frame import H5DataFramea\n",
+    "    from gedi_subset.h5frame import H5DataFrame\n",
     "\n",
     "from h5coro import h5coro, s3driver, filedriver\n",
     "h5coro.config(errorChecking=True, verbose=False, enableAttributes=False)"

--- a/notebooks/first-benchmark.ipynb
+++ b/notebooks/first-benchmark.ipynb
@@ -9,6 +9,7 @@
    "source": [
     "import cProfile\n",
     "import earthaccess\n",
+    "import h5py\n",
     "import numpy as np\n",
     "import xarray as xr\n",
     "\n",
@@ -17,6 +18,12 @@
     "except:\n",
     "    !mamba install -c conda-forge h5coro --yes\n",
     "    import h5coro\n",
+    "\n",
+    "try:\n",
+    "    from gedi_subset.h5frame import H5DataFrame\n",
+    "except ImportError:\n",
+    "    !pip install git+https://github.com/MAAP-Project/gedi-subsetter.git@0.6.0\n",
+    "    from gedi_subset.h5frame import H5DataFramea\n",
     "\n",
     "from h5coro import h5coro, s3driver, filedriver\n",
     "h5coro.config(errorChecking=True, verbose=False, enableAttributes=False)"
@@ -73,7 +80,7 @@
      "output_type": "stream",
      "text": [
       "You're now authenticated with NASA Earthdata Login\n",
-      "Using token with expiration date: 08/25/2023\n",
+      "Using token with expiration date: 08/26/2023\n",
       "Using user provided credentials for EDL\n"
      ]
     }
@@ -183,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "id": "c74c35c2-b921-457a-846a-fb692a1c954d",
    "metadata": {
     "tags": []
@@ -193,26 +200,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 18.9 s, sys: 4.86 s, total: 23.7 s\n",
-      "Wall time: 1min 4s\n"
+      "681.68933\n",
+      "CPU times: user 19.8 s, sys: 4.18 s, total: 23.9 s\n",
+      "Wall time: 1min 3s\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "681.68933"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
     "%%time\n",
     "#cProfile.run(\"xr.open_dataset(s3access.open(s3url, 'rb'), group='/gt2l/heights')\")\n",
     "ds = xr.open_dataset(s3access.open(s3url, 'rb'), group='/gt2l/heights')\n",
-    "ds['h_ph'].values.mean()"
+    "print(ds['h_ph'].values.mean())"
    ]
   },
   {
@@ -238,23 +236,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 136 ms, sys: 57 ms, total: 193 ms\n",
-      "Wall time: 811 ms\n"
+      "681.68933\n",
+      "681.68933\n",
+      "681.68933\n",
+      "681.68933\n",
+      "681.68933\n",
+      "681.68933\n",
+      "681.68933\n",
+      "681.68933\n",
+      "486 ms ± 29.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "681.68933"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "h5obj = h5coro.H5Coro(f'{bucket}/{path_to_hdf5_file}', \n",
     "                      s3driver.S3Driver,\n",
     "                      credentials={\"aws_access_key_id\": s3_creds[\"accessKeyId\"],\n",
@@ -263,7 +258,49 @@
     "\n",
     "dataset = '/gt2l/heights/h_ph'\n",
     "output = h5obj.readDatasets(datasets=[dataset], block=True)\n",
-    "h5obj[dataset].values.mean()"
+    "print(h5obj[dataset].values.mean())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d34ceba4-ba41-458d-871a-14b5e7f81e90",
+   "metadata": {
+    "tags": [],
+    "user_expressions": []
+   },
+   "source": [
+    "## h5py (via gedi_subset's H5DataFrame)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "980b055d-0d2d-416c-a517-c10adf1ef659",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "681.68933\n",
+      "681.68933\n",
+      "681.68933\n",
+      "681.68933\n",
+      "681.68933\n",
+      "681.68933\n",
+      "681.68933\n",
+      "681.68933\n",
+      "747 ms ± 23 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "with h5py.File(name=s3access.open(path=s3url, mode=\"rb\")) as h5:\n",
+    "    df = H5DataFrame(h5[\"gt2l/heights\"])\n",
+    "    print(df[\"h_ph\"].mean())"
    ]
   },
   {
@@ -284,7 +321,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "180cae83-e3f2-4840-912e-9b2cc56b45f8",
    "metadata": {
     "tags": []


### PR DESCRIPTION
Taking about 747 ms ± 23 ms per loop (mean ± std. dev. of 7 runs, 1 loop each). Need to install gedi_subset manually from https://github.com/MAAP-Project/gedi-subsetter.

Benchmarks ran on CryoCloud's ICESat-2 Hackweek 2023 node share instance with (total of) 16-20GB of RAM and 2-4 CPU max.

Usage:

```python
# !pip install git+https://github.com/MAAP-Project/gedi-subsetter.git@0.6.0
import h5py
import earthaccess

from gedi_subset.h5frame import H5DataFrame

auth = earthaccess.login()
s3 = earthaccess.get_s3fs_session(daac="NSIDC")

s3url = "s3://nsidc-cumulus-prod-protected/ATLAS/ATL03/005/2020/01/01/ATL03_20200101053635_00840606_005_01.h5"
with h5py.File(name=s3access.open(path=s3url, mode="rb")) as h5:
    df = H5DataFrame(h5["gt2l/heights"])
    print(df["h_ph"].mean())
```

References:
- https://github.com/MAAP-Project/gedi-subsetter/blob/0.6.0/src/gedi_subset/h5frame.py#L10